### PR TITLE
create pyproject.toml to guarantee pypandoc is installed before setup.py executes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+pip-wheel-metadata
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ You will need to install the following dependencies:
 
 * requests
 * six
-* pypandoc
 
 This can be done either manually or via pip with the included `requirements.txt` file as follows:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[build-system]
-requires = ["pypandoc"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["pypandoc"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests
 six
-pypandoc

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-import os,sys,pypandoc
+import os,sys
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
@@ -19,17 +19,13 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 def makeLongDescription():
-    return pypandoc.convert_file('README.md', 'rst')
-
-try: long_description=makeLongDescription()
-except OSError:
-    from pypandoc.pandoc_download import download_pandoc
-    download_pandoc()
-    long_description=makeLongDescription()
+    this_directory = os.path.abspath(os.path.dirname(__file__))
+    with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+        return f.read()
 
 setup(
     name="PushySDK",
-    version="0.1.5",
+    version="0.1.6",
     author="Rob Kent",
     author_email="jazzycamel@googlemail.com",
     description="A very simple Python client for the Pushy notification service API.",
@@ -40,7 +36,8 @@ setup(
     install_requires=['requests','six'],
     tests_require=['pytest','pytest-cov'],
     cmdclass={'test': PyTest},
-    long_description=long_description,
+    long_description=makeLongDescription(),
+    long_description_content_type='text/markdown',
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-import os,sys
+import os,sys,pypandoc
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
@@ -18,17 +18,14 @@ class PyTest(TestCommand):
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
-
 def makeLongDescription():
-    import pypandoc  # imported here to avoid import errors when running setup.py install before installing requirements
+    return pypandoc.convert_file('README.md', 'rst')
 
-    try:
-        return pypandoc.convert_file('README.md', 'rst')
-    except OSError:
-        from pypandoc.pandoc_download import download_pandoc
-        download_pandoc()
-        return pypandoc.convert_file('README.md', 'rst')    
-
+try: long_description=makeLongDescription()
+except OSError:
+    from pypandoc.pandoc_download import download_pandoc
+    download_pandoc()
+    long_description=makeLongDescription()
 
 setup(
     name="PushySDK",
@@ -40,10 +37,10 @@ setup(
     keywords="Pushy Notification API",
     url="https://github.com/jazzycamel/pushy",
     packages=find_packages(exclude=['docs','tests']),
-    install_requires=['requests','six','pypandoc'],
+    install_requires=['requests','six'],
     tests_require=['pytest','pytest-cov'],
     cmdclass={'test': PyTest},
-    long_description=makeLongDescription(),
+    long_description=long_description,
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-import os,sys,pypandoc
+import os,sys
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
@@ -18,14 +18,17 @@ class PyTest(TestCommand):
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
-def makeLongDescription():
-    return pypandoc.convert_file('README.md', 'rst')
 
-try: long_description=makeLongDescription()
-except OSError:
-    from pypandoc.pandoc_download import download_pandoc
-    download_pandoc()
-    long_description=makeLongDescription()
+def makeLongDescription():
+    import pypandoc  # imported here to avoid import errors when running setup.py install before installing requirements
+
+    try:
+        return pypandoc.convert_file('README.md', 'rst')
+    except OSError:
+        from pypandoc.pandoc_download import download_pandoc
+        download_pandoc()
+        return pypandoc.convert_file('README.md', 'rst')    
+
 
 setup(
     name="PushySDK",
@@ -37,10 +40,10 @@ setup(
     keywords="Pushy Notification API",
     url="https://github.com/jazzycamel/pushy",
     packages=find_packages(exclude=['docs','tests']),
-    install_requires=['requests','six'],
+    install_requires=['requests','six','pypandoc'],
     tests_require=['pytest','pytest-cov'],
     cmdclass={'test': PyTest},
-    long_description=long_description,
+    long_description=makeLongDescription(),
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
pip installing directly from master throws an error because setup.py requires pypandoc, but pypandoc hasn't been installed from requirements yet. Putting pypandoc in pyproject.toml guarantees that pypandoc will get installed before setup.py executes.

Sorry for the messy history, please feel free to squash!